### PR TITLE
feat(style): Add all color variables not only colors alias to project

### DIFF
--- a/src/Styles/colorVariables.styles.ts
+++ b/src/Styles/colorVariables.styles.ts
@@ -1,0 +1,48 @@
+const colorVariables = {
+  //PRIMARY
+  primaryBlueColor: `#55789B`,
+  primaryBlueExtraLightColor: `#F0F7FF`,
+  primaryBlueLightColor: `#E3EAF2`,
+  primaryBlueDarkColor: `#305677`,
+  primaryBlueExtraDarkColor: `#002D4B`,
+  primaryOrangeColor: `#E68430`,
+  primaryOrangeLightColor: `#FFB678`,
+  primaryOrangeDarkColor: `#CF7D38`,
+  primaryPaperColor: `#F7F3EA`,
+  primaryWhiteColor: `#F7F3EA`,
+
+  //SEMANTIC
+  semanticSuccessBorderColor: ` #C3E6CB`,
+  semanticSuccessTextColor: `#155724`,
+  semanticInfoColor: `#CCE5FF`,
+  semanticInfoBorderColor: `#B8DAFF`,
+  semanticInfoTextColor: `#0064B8`,
+  semanticWarningColor: `#FFF3CD`,
+  semanticWarningBorderColor: `#FFEEBA`,
+  semanticWarningTextColor: `#896404`,
+  semanticDangerColor: `#F8D7DA`,
+  semanticDangerBorderColor: `#F5C6CB`,
+  primaryDangerTextColor: `#9D1C24`,
+
+  //NEUTRAL
+  neutralBlack100Color: `#1F1F1F`,
+  neutralBlack60Color: `#545454`,
+  neutralBlack40Color: `#808080`,
+  neutralBlack20Color: `#AEAEAE`,
+  neutralBlack10Color: `#D6D6D6`,
+  neutralBlack5Color: `#E8E8E8`,
+
+  // COLORS-ALIAS
+  // ICONS
+  iconsBlack40Color: `#808080`,
+
+  //BACKGROUND CTA
+  BackgroundCtaColor: `#112F45`,
+  BackgroundCtaDarkColor: `#305677`,
+  BackgroundCtaExtraDarkColor: `#0A2336`,
+
+  //BACKGROUND PAGE
+  backgroundPageColor: `#F7F3EA`
+};
+
+export default colorVariables;


### PR DESCRIPTION

#19/ Add all color variables not only colors alias to project


## Description
J'ai ajouté des variables de couleurs à COLORS ALIAS

<img width="688" alt="image" src="https://user-images.githubusercontent.com/69139728/157468456-efe2c78a-134d-40bf-9924-707f5fe13867.png">

Et j'ai également ajouté des variables de couleurs aux autres colors existantes dans notre application ce qui est aussi utile je trouve! Vous me dites :)

<img width="397" alt="image" src="https://user-images.githubusercontent.com/69139728/157469080-60339a02-d638-4561-b0bf-fd1008b18d95.png">

